### PR TITLE
Alter test spec

### DIFF
--- a/src/storage/storage.js
+++ b/src/storage/storage.js
@@ -166,21 +166,24 @@ export class Storage {
         if (this.terminal) {
           if (field !== $self) {
             if (value !== null) {
-              return this[$emitter].next({
+              this[$emitter].next({
                 type, id, field, value: value[field],
               });
+              return null;
             } else {
               return this.readMany(type, id, field)
               .then((list) => {
-                return this[$emitter].next({
+                this[$emitter].next({
                   type, id, field, value: list[field],
                 });
+                return null;
               });
             }
           } else {
-            return this[$emitter].next({
+            this[$emitter].next({
               type, id, value,
             });
+            return null;
           }
         } else {
           return null;

--- a/src/test/testType.js
+++ b/src/test/testType.js
@@ -171,7 +171,7 @@ QueryChildren.$extras = {
   },
 };
 
-QueryChildren.$name = 'valence_children';
+QueryChildren.$name = 'query_children';
 
 
 TestType.$name = 'tests';


### PR DESCRIPTION
Specificially, QueryChildren in testType.js has been changed to be named 'query_children' instead of 'valence_children' which was me being lazy and not creating a new table in the sql type tests.