### PR TITLE
failing tests

### DIFF
--- a/dist/test/model.spec.js
+++ b/dist/test/model.spec.js
@@ -213,6 +213,30 @@ describe('model', function () {
       });
     });
 
+    it('should pass model changes to other models', function () {
+      var one = new _testType.TestType({ name: 'potato' }, plump);
+      return one.$save().then(function () {
+        var onePrime = plump.find(_testType.TestType.$name, one.$id);
+        return one.$get().then(function (res) {
+          return expect(res).have.property('name', 'potato');
+        }).then(function () {
+          return onePrime.$get();
+        }).then(function (res) {
+          return expect(res).have.property('name', 'potato');
+        }).then(function () {
+          return one.$set('name', 'grotato');
+        }).then(function () {
+          return one.$get();
+        }).then(function (res) {
+          return expect(res).have.property('name', 'grotato');
+        }).then(function () {
+          return onePrime.$get();
+        }).then(function (res) {
+          return expect(res).have.property('name', 'grotato');
+        });
+      });
+    });
+
     it('should allow subscription to model data', function (done) {
       var one = new _testType.TestType({ name: 'potato' }, plump);
       var phase = 0;

--- a/dist/test/model.spec.js
+++ b/dist/test/model.spec.js
@@ -189,6 +189,30 @@ describe('model', function () {
   });
 
   describe('events', function () {
+    it('should pass model hasMany changes to other models', function () {
+      var one = new _testType.TestType({ name: 'potato' }, plump);
+      return one.$save().then(function () {
+        var onePrime = plump.find(_testType.TestType.$name, one.$id);
+        return one.$get('children').then(function (res) {
+          return expect(res).to.deep.equal({ children: [] });
+        }).then(function () {
+          return onePrime.$get('children');
+        }).then(function (res) {
+          return expect(res).to.deep.equal({ children: [] });
+        }).then(function () {
+          return one.$add('children', 100);
+        }).then(function () {
+          return one.$get('children');
+        }).then(function (res) {
+          return expect(res).to.deep.equal({ children: [{ id: 100 }] });
+        }).then(function () {
+          return onePrime.$get('children');
+        }).then(function (res) {
+          return expect(res).to.deep.equal({ children: [{ id: 100 }] });
+        });
+      });
+    });
+
     it('should allow subscription to model data', function (done) {
       var one = new _testType.TestType({ name: 'potato' }, plump);
       var phase = 0;

--- a/src/test/model.spec.js
+++ b/src/test/model.spec.js
@@ -175,6 +175,23 @@ describe('model', () => {
       });
     });
 
+    it('should pass model changes to other models', () => {
+      const one = new TestType({ name: 'potato' }, plump);
+      return one.$save()
+      .then(() => {
+        const onePrime = plump.find(TestType.$name, one.$id);
+        return one.$get()
+        .then((res) => expect(res).have.property('name', 'potato'))
+        .then(() => onePrime.$get())
+        .then((res) => expect(res).have.property('name', 'potato'))
+        .then(() => one.$set('name', 'grotato'))
+        .then(() => one.$get())
+        .then((res) => expect(res).have.property('name', 'grotato'))
+        .then(() => onePrime.$get())
+        .then((res) => expect(res).have.property('name', 'grotato'));
+      });
+    });
+
     it('should allow subscription to model data', (done) => {
       const one = new TestType({ name: 'potato' }, plump);
       let phase = 0;

--- a/src/test/model.spec.js
+++ b/src/test/model.spec.js
@@ -158,6 +158,23 @@ describe('model', () => {
   });
 
   describe('events', () => {
+    it('should pass model hasMany changes to other models', () => {
+      const one = new TestType({ name: 'potato' }, plump);
+      return one.$save()
+      .then(() => {
+        const onePrime = plump.find(TestType.$name, one.$id);
+        return one.$get('children')
+        .then((res) => expect(res).to.deep.equal({ children: [] }))
+        .then(() => onePrime.$get('children'))
+        .then((res) => expect(res).to.deep.equal({ children: [] }))
+        .then(() => one.$add('children', 100))
+        .then(() => one.$get('children'))
+        .then((res) => expect(res).to.deep.equal({ children: [{ id: 100 }] }))
+        .then(() => onePrime.$get('children'))
+        .then((res) => expect(res).to.deep.equal({ children: [{ id: 100 }] }));
+      });
+    });
+
     it('should allow subscription to model data', (done) => {
       const one = new TestType({ name: 'potato' }, plump);
       let phase = 0;


### PR DESCRIPTION
Plump currently does not invalidate extant models when the underlying data changes in all cases.