### PR TITLE
adding fetch cache

### DIFF
--- a/dist/model.js
+++ b/dist/model.js
@@ -243,25 +243,29 @@ var Model = exports.Model = function () {
                 var colds = this.plump.caches.filter(function (s) {
                     return !s.hot(_this5);
                 });
-                var read$ = this.plump.terminal.write$.filter(function (v) {
-                    return v.type === _this5.type && v.id === _this5.id // && v.invalidate.some(i => fields.indexOf(i) >= 0)
-                    ;
-                }).startWith({
-                    id: this.id,
-                    type: this.type,
-                    invalidate: readReq.fields
-                }).flatMap(function (v) {
-                    return _rxjs.Observable.fromPromise(_this5.get({
-                        fields: v.invalidate
-                    }).then(function (v) {
-                        if (v) {
-                            return v;
-                        } else {
-                            _this5.error = _this5.error || new _errors.NotFoundError();
-                            return _this5.empty(_this5.id, 'not found');
-                        }
-                    }));
-                }).publishReplay(1).refCount();
+                // THIS IS A MEMORY LEAK
+                if (!this.plump.readCache[this.type + ':' + this.id]) {
+                    this.plump.readCache[this.type + ':' + this.id] = this.plump.terminal.write$.filter(function (v) {
+                        return v.type === _this5.type && v.id === _this5.id // && v.invalidate.some(i => fields.indexOf(i) >= 0)
+                        ;
+                    }).startWith({
+                        id: this.id,
+                        type: this.type,
+                        invalidate: readReq.fields
+                    }).flatMap(function (v) {
+                        return _rxjs.Observable.fromPromise(_this5.get({
+                            fields: v.invalidate
+                        }).then(function (v) {
+                            if (v) {
+                                return v;
+                            } else {
+                                _this5.error = _this5.error || new _errors.NotFoundError();
+                                return _this5.empty(_this5.id, 'not found');
+                            }
+                        }));
+                    }).publishReplay(1).refCount();
+                }
+                var read$ = this.plump.readCache[this.type + ':' + this.id];
                 var cold$ = _rxjs.Observable.fromPromise(Promise.all(colds.map(function (h) {
                     return h.read(readReq);
                 })).then(function (results) {

--- a/dist/plump.d.ts
+++ b/dist/plump.d.ts
@@ -12,6 +12,7 @@ export declare class Plump<TermType extends TerminalStore = TerminalStore> {
     terminal: TermType;
     destroy$: Observable<string>;
     caches: CacheStore[];
+    readCache: {};
     types: TypeMap;
     teardownSubject: Subject<string>;
     constructor(terminal: TermType);

--- a/dist/plump.js
+++ b/dist/plump.js
@@ -37,6 +37,7 @@ var Plump = exports.Plump = function () {
         _classCallCheck(this, Plump);
 
         this.terminal = terminal;
+        this.readCache = {};
         this.types = {};
         this.teardownSubject = new _rxjs.Subject();
         this.terminal.terminal = true;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "plump",
-  "version": "0.27.0",
+  "version": "0.27.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -11,7 +11,12 @@
     "type": "git",
     "url": "git+https://github.com/plumpstack/plump.git"
   },
-  "keywords": ["typescript", "orm", "datastore", "activerecord"],
+  "keywords": [
+    "typescript",
+    "orm",
+    "datastore",
+    "activerecord"
+  ],
   "author": "Eric Eslinger <eric.eslinger@gmail.com>",
   "license": "MIT",
   "bugs": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "plump",
-  "version": "0.27.1",
+  "version": "0.27.2",
   "description": "Pluggable Datastore",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -11,12 +11,7 @@
     "type": "git",
     "url": "git+https://github.com/plumpstack/plump.git"
   },
-  "keywords": [
-    "typescript",
-    "orm",
-    "datastore",
-    "activerecord"
-  ],
+  "keywords": ["typescript", "orm", "datastore", "activerecord"],
   "author": "Eric Eslinger <eric.eslinger@gmail.com>",
   "license": "MIT",
   "bugs": {

--- a/src/model.ts
+++ b/src/model.ts
@@ -76,14 +76,14 @@ export class Model<MD extends ModelData> {
         retVal.attributes[key] = this.schema.attributes[key].default || 0;
       } else if (this.schema.attributes[key].type === 'date') {
         retVal.attributes[key] = new Date(
-          (this.schema.attributes[key].default as any) || Date.now()
+          (this.schema.attributes[key].default as any) || Date.now(),
         );
       } else if (this.schema.attributes[key].type === 'string') {
         retVal.attributes[key] = this.schema.attributes[key].default || '';
       } else if (this.schema.attributes[key].type === 'object') {
         retVal.attributes[key] = Object.assign(
           {},
-          this.schema.attributes[key].default
+          this.schema.attributes[key].default,
         );
       } else if (this.schema.attributes[key].type === 'array') {
         retVal.attributes[key] = (
@@ -111,7 +111,7 @@ export class Model<MD extends ModelData> {
     this.error = null;
     if (this.type === 'BASE') {
       throw new TypeError(
-        'Cannot instantiate base plump Models, please subclass with a schema and valid type'
+        'Cannot instantiate base plump Models, please subclass with a schema and valid type',
       );
     }
     let initialValue = opts;
@@ -183,7 +183,7 @@ export class Model<MD extends ModelData> {
       .get(
         mergeOptions({}, req, {
           item: { id: this.id, type: this.type },
-        })
+        }),
       )
       .catch((e: PlumpError) => {
         this.error = e;
@@ -200,12 +200,12 @@ export class Model<MD extends ModelData> {
         } else {
           const resolved = Model.resolveAndOverlay(
             this.dirty,
-            self || undefined
+            self || undefined,
           );
           return mergeOptions(
             {},
             self || { id: this.id, type: this.type },
-            resolved
+            resolved,
           );
         }
       });
@@ -220,7 +220,7 @@ export class Model<MD extends ModelData> {
   save(opts: any = { stripId: true }): Promise<MD> {
     const update: DirtyModel = mergeOptions(
       { id: this.id, type: this.type },
-      this.dirty
+      this.dirty,
     );
     if (
       Object.keys(this.dirty.attributes).length +
@@ -257,7 +257,7 @@ export class Model<MD extends ModelData> {
       if (fields.indexOf('relationships') >= 0) {
         fields.splice(fields.indexOf('relationships'), 1);
         fields = fields.concat(
-          Object.keys(this.schema.relationships).map(k => `relationships.${k}`)
+          Object.keys(this.schema.relationships).map(k => `relationships.${k}`),
         );
       }
       return {
@@ -286,56 +286,63 @@ export class Model<MD extends ModelData> {
 
   asObservable(opts?: ReadRequest | string | string[]): Observable<MD> {
     const readReq = this.parseOpts(
-      opts || { fields: ['attributes', 'relationships'] }
+      opts || { fields: ['attributes', 'relationships'] },
     );
     const reqKey = this.stringifyRequest(readReq);
     if (!this.observableCache[reqKey]) {
       const colds = this.plump.caches.filter(s => !s.hot(this));
 
-      const read$ = this.plump.terminal.write$
-        .filter((v: ModelDelta) => {
-          return (
-            v.type === this.type && v.id === this.id // && v.invalidate.some(i => fields.indexOf(i) >= 0)
-          );
-        })
-        .startWith({
-          id: this.id,
-          type: this.type,
-          invalidate: readReq.fields,
-        })
-        .flatMap(v =>
-          Observable.fromPromise(
-            this.get({
-              fields: v.invalidate,
-            }).then(v => {
-              if (v) {
-                return v;
-              } else {
-                this.error = this.error || new NotFoundError();
-                return this.empty(this.id, 'not found');
-              }
-            })
+      // THIS IS A MEMORY LEAK - temporarily here for perf testing
+
+      if (!this.plump.readCache[`${this.type}:${this.id}`]) {
+        this.plump.readCache[
+          `${this.type}:${this.id}`
+        ] = this.plump.terminal.write$
+          .filter((v: ModelDelta) => {
+            return (
+              v.type === this.type && v.id === this.id // && v.invalidate.some(i => fields.indexOf(i) >= 0)
+            );
+          })
+          .startWith({
+            id: this.id,
+            type: this.type,
+            invalidate: readReq.fields,
+          })
+          .flatMap(v =>
+            Observable.fromPromise(
+              this.get({
+                fields: v.invalidate,
+              }).then(v => {
+                if (v) {
+                  return v;
+                } else {
+                  this.error = this.error || new NotFoundError();
+                  return this.empty(this.id, 'not found');
+                }
+              }),
+            ),
           )
-        )
-        .publishReplay(1)
-        .refCount();
+          .publishReplay(1)
+          .refCount();
+      }
+      const read$ = this.plump.readCache[`${this.type}:${this.id}`];
 
       const cold$: Observable<ModelData> = Observable.fromPromise(
         Promise.all(colds.map(h => h.read(readReq))).then(results =>
-          condMerge(results)
-        )
+          condMerge(results),
+        ),
       ).takeUntil(read$);
 
       this.observableCache[reqKey] = Observable.merge(
         read$,
         cold$,
-        this._write$.asObservable()
+        this._write$.asObservable(),
       )
         .scan((acc, curr) => {
           const rv = condMerge([acc, curr]);
           rv.relationships = Model.resolveRelationships(
             this.dirty.relationships,
-            rv.relationships
+            rv.relationships,
           );
           return rv;
         }, this.empty(this.id))
@@ -355,7 +362,7 @@ export class Model<MD extends ModelData> {
     const toAdd: TypedRelationshipItem = Object.assign(
       {},
       { type: this.schema.relationships[key].type.sides[key].otherType },
-      item
+      item,
     );
     if (key in this.schema.relationships) {
       if (item.id >= 1) {
@@ -381,7 +388,7 @@ export class Model<MD extends ModelData> {
     const toAdd: TypedRelationshipItem = Object.assign(
       {},
       { type: this.schema.relationships[key].type.sides[key].otherType },
-      item
+      item,
     );
     if (key in this.schema.relationships) {
       if (item.id >= 1) {
@@ -404,7 +411,7 @@ export class Model<MD extends ModelData> {
     const toAdd: TypedRelationshipItem = Object.assign(
       {},
       { type: this.schema.relationships[key].type.sides[key].otherType },
-      item
+      item,
     );
     if (key in this.schema.relationships) {
       if (item.id >= 1) {
@@ -441,25 +448,25 @@ export class Model<MD extends ModelData> {
     base: { attributes?: any; relationships?: any } = {
       attributes: {},
       relationships: {},
-    }
+    },
   ) {
     const attributes = mergeOptions({}, base.attributes, update.attributes);
     const resolvedRelationships = this.resolveRelationships(
       update.relationships,
-      base.relationships
+      base.relationships,
     );
     return { attributes, relationships: resolvedRelationships };
   }
 
   static resolveRelationships(
     deltas: StringIndexed<RelationshipDelta[]>,
-    base: StringIndexed<TypedRelationshipItem[]> = {}
+    base: StringIndexed<TypedRelationshipItem[]> = {},
   ) {
     const updates = Object.keys(deltas)
       .map(relName => {
         const resolved = this.resolveRelationship(
           deltas[relName],
-          base[relName]
+          base[relName],
         );
         return { [relName]: resolved };
       })
@@ -469,7 +476,7 @@ export class Model<MD extends ModelData> {
 
   static resolveRelationship(
     deltas: RelationshipDelta[],
-    base: TypedRelationshipItem[] = []
+    base: TypedRelationshipItem[] = [],
   ) {
     const retVal = base.concat();
     deltas.forEach(delta => {

--- a/src/plump.ts
+++ b/src/plump.ts
@@ -40,6 +40,7 @@ export function pathExists(obj: any, path: string) {
 export class Plump<TermType extends TerminalStore = TerminalStore> {
   public destroy$: Observable<string>;
   public caches: CacheStore[];
+  readCache = {};
   public types: TypeMap = {};
 
   public teardownSubject: Subject<string>;


### PR DESCRIPTION
this implementation leaks references to an observable (but does not leak subscriptions). This is problematic, but fills an important perf gap. use at your own risk for now. this will be fixed in a future patch (pretty sure we can delete the cache entry with a cleanup call by examining the number of subscribers on the cached refcounted observable.)